### PR TITLE
Updates &#42; characters to an escaped *

### DIFF
--- a/docs/settings/apm-settings.asciidoc
+++ b/docs/settings/apm-settings.asciidoc
@@ -17,12 +17,12 @@ xpack.apm.enabled:: Set to `false` to disabled the APM plugin {kib}. Defaults to
 xpack.apm.ui.enabled:: Set to `false` to hide the APM plugin {kib} from the menu. Defaults to
 `true`.
 
-apm_oss.indexPattern:: Index pattern is used for integrations with Machine Learning and Kuery Bar. It must match all apm indices. Defaults to `apm-&#42;`.
+apm_oss.indexPattern:: Index pattern is used for integrations with Machine Learning and Kuery Bar. It must match all apm indices. Defaults to `apm-*`.
 
-apm_oss.errorIndices:: Matcher for indices containing error documents. Defaults to `apm-&#42;-error-&#42;`.
+apm_oss.errorIndices:: Matcher for indices containing error documents. Defaults to `apm-\*-error-*`.
 
-apm_oss.onboardingIndices:: Matcher for indices containing onboarding documents. Defaults to `apm-&#42;-onboarding-&#42;`.
+apm_oss.onboardingIndices:: Matcher for indices containing onboarding documents. Defaults to `apm-\*-onboarding-*`.
 
-apm_oss.spanIndices:: Matcher for indices containing span documents. Defaults to `apm-&#42;-span-&#42;`.
+apm_oss.spanIndices:: Matcher for indices containing span documents. Defaults to `apm-\*-span-*`.
 
-apm_oss.transactionIndices:: Matcher for indices containing transaction documents. Defaults to `apm-&#42;-transaction-&#42;`.
+apm_oss.transactionIndices:: Matcher for indices containing transaction documents. Defaults to `apm-\*-transaction-*`.


### PR DESCRIPTION
GitHub's asciidoc parser handles `*` characters fine but markdown thinks its italicizing unless you escape the first asterisk. Subsequent asterisks on the same line can stay unescaped and should work fine.

<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `yarn test && yarn build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
-->