### PR TITLE
Make ES clone fall back to master

### DIFF
--- a/src/dev/ci_setup/git_setup.sh
+++ b/src/dev/ci_setup/git_setup.sh
@@ -73,8 +73,14 @@ function checkout_sibling {
         return 0
       fi
 
-      # remove xpack_ prefix from target branch if all other options fail
+      # try removing xpack_ prefix from target branch
       cloneBranch="${PR_TARGET_BRANCH#xpack_}"
+      if clone_target_is_valid ; then
+        return 0
+      fi
+      
+      # if all else fails, use master
+      cloneBranch=master
       return 0
     }
 


### PR DESCRIPTION
Sometimes it is nice to create a feature or release type branch in kibana where you are merging smaller chunks of work into a larger branch before merging the larger branch to master. In that case, your PR source may be `jasonrhodes/kibana:small-thing-1` and the target branch may be something like `elastic/kibana:feature/big-thing`. The current CI git setup will attempt to clone elasticsearch from the following locations:

* `jasonrhodes/elasticsearch:small-thing-1`
* `elastic/elasticsearch:small-thing-1`
* `elastic/elasticsearch:feature/big-thing`

If all of these branches fail to exist, the build fails. But I would think in many cases a Kibana PR has no corresponding changes in Elasticsearch, so it'd be nice in those cases if the build could fall back to cloning ES from `elastic/elasticsearch:master`...

Is there a problem with that fallback that I don't understand (very likely!)? Thanks!

<!--
Thank you for your interest in and contributing to Kibana! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/kibana/blob/master/CONTRIBUTING.md)?
- If submitting code, have you included unit tests that cover the changes?
- If submitting code, have you tested and built your code locally prior to submission with `yarn test && yarn build`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
-->