### PR TITLE
update x-pack to eui 5.1.0, clean up some ts defs

### DIFF
--- a/src/ui/public/query_bar/components/language_switcher.tsx
+++ b/src/ui/public/query_bar/components/language_switcher.tsx
@@ -17,10 +17,6 @@
  * under the License.
  */
 
-declare module '@elastic/eui' {
-  export const EuiPopoverTitle: React.SFC<any>;
-}
-
 import {
   EuiButtonEmpty,
   EuiForm,

--- a/x-pack/package.json
+++ b/x-pack/package.json
@@ -118,7 +118,7 @@
   },
   "dependencies": {
     "@elastic/datemath": "^4.0.2",
-    "@elastic/eui": "5.0.0",
+    "@elastic/eui": "^5.1.0",
     "@elastic/node-crypto": "0.1.2",
     "@elastic/node-phantom-simple": "2.2.4",
     "@elastic/numeral": "2.3.2",

--- a/x-pack/plugins/apm/public/components/shared/HistoryTabs/__test__/HistoryTabs.test.tsx
+++ b/x-pack/plugins/apm/public/components/shared/HistoryTabs/__test__/HistoryTabs.test.tsx
@@ -15,6 +15,11 @@ import {
   IHistoryTab
 } from '..';
 
+type PropsOf<Component> = Component extends React.SFC<infer Props>
+  ? Props
+  : never;
+type EuiTabProps = PropsOf<typeof EuiTab>;
+
 describe('HistoryTabs', () => {
   let mockLocation: any;
   let mockHistory: any;
@@ -61,7 +66,7 @@ describe('HistoryTabs', () => {
     const wrapper = shallow(<HistoryTabsWithoutRouter {...testProps} />);
     expect(wrapper).toMatchSnapshot();
 
-    const tabs: ShallowWrapper<EuiTab> = wrapper.find(EuiTab);
+    const tabs: ShallowWrapper<EuiTabProps> = wrapper.find(EuiTab);
     expect(tabs.at(0).props().isSelected).toEqual(false);
     expect(tabs.at(1).props().isSelected).toEqual(true);
     expect(tabs.at(2).props().isSelected).toEqual(false);
@@ -81,7 +86,7 @@ describe('HistoryTabs', () => {
       .at(2)
       .simulate('click');
 
-    const tabs: ReactWrapper<EuiTab> = wrapper.find(EuiTab);
+    const tabs: ReactWrapper<EuiTabProps> = wrapper.find(EuiTab);
     expect(tabs.at(0).props().isSelected).toEqual(false);
     expect(tabs.at(1).props().isSelected).toEqual(false);
     expect(tabs.at(2).props().isSelected).toEqual(true);

--- a/x-pack/plugins/infra/types/eui.d.ts
+++ b/x-pack/plugins/infra/types/eui.d.ts
@@ -141,8 +141,6 @@ declare module '@elastic/eui' {
     children: React.ReactNode;
   };
 
-  export const EuiErrorBoundary: React.SFC<EuiErrorBoundaryProps>;
-
   type EuiSizesResponsive = 'xs' | 's' | 'm' | 'l' | 'xl';
   type EuiResponsiveProps = CommonProps & {
     children: React.ReactNode;
@@ -164,13 +162,4 @@ declare module '@elastic/eui' {
   };
 
   export const EuiDatePickerRange: React.SFC<EuiDatePickerRangeProps>;
-
-  export type EuiBetaBadgeProps = CommonProps & {
-    iconType?: IconType;
-    label: React.ReactNode;
-    title?: string;
-    tooltipContent?: React.ReactNode;
-    tooltipPosition?: EuiToolTipPosition;
-  };
-  export const EuiBetaBadge: React.SFC<EuiBetaBadgeProps>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -746,31 +746,7 @@
     tabbable "^1.1.0"
     uuid "^3.1.0"
 
-"@elastic/eui@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-5.0.0.tgz#e6fe9e1aa8b00c93045178f78a6dd0d457d56fa8"
-  integrity sha512-WL6sp6u2Rt1O7a2exLU/RuDcRnpluPN6aQ2JexBl+G6mVyF8F5I3RGJKTJp3jOozOaODRY2ev+Nq57EydkjrKg==
-  dependencies:
-    classnames "^2.2.5"
-    core-js "^2.5.1"
-    focus-trap-react "^3.0.4"
-    highlight.js "^9.12.0"
-    html "^1.0.0"
-    keymirror "^0.1.1"
-    lodash "npm:@elastic/lodash@3.10.1-kibana1"
-    numeral "^2.0.6"
-    prop-types "^15.6.0"
-    react-ace "^5.5.0"
-    react-color "^2.13.8"
-    react-datepicker v1.5.0
-    react-input-autosize "^2.2.1"
-    react-virtualized "^9.18.5"
-    react-vis "1.10.2"
-    resize-observer-polyfill "^1.5.0"
-    tabbable "^1.1.0"
-    uuid "^3.1.0"
-
-"@elastic/eui@^5.1.0":
+"@elastic/eui@5.1.0":
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/@elastic/eui/-/eui-5.1.0.tgz#fdc17af319567e500002f79404a2e33748501f6c"
   integrity sha512-ZVUQYO7uP1M1NyPmzal16SKbjA3PwxR393YpcKJ/Wytqi4kHEeJNLVGQoRGBSJ3Qw0ivU91i5+RuefkyPj67tw==


### PR DESCRIPTION
- upgrades EUI version in x-pack to 5.1.0 to match Kibana's (fixes the majority of TS errors)
- resolves handful of EUI TS definitions now duplicated in Kibana