### PR TITLE
Improved error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
-    "@elastic/asset-collection": "^0.3.0",
+    "@elastic/asset-collection": "^0.4.0",
     "@elastic/charts": "51.1.1",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.5.0-canary.1",

--- a/x-pack/plugins/asset_inventory/server/lib/collect_assets.ts
+++ b/x-pack/plugins/asset_inventory/server/lib/collect_assets.ts
@@ -23,7 +23,12 @@ export async function collectAssets({ types }: { types: string[] }) {
   };
 
   if (doAll || types.includes('aws-k8s')) {
-    results.push(loadAwsK8s(ES_CONFIG));
+    if (!process.env.ASSETS_AWS_REGIONS) {
+      throw new Error(
+        'Cannot collect AWS K8s assets without specifying one or more valid AWS regions, provided as ASSETS_AWS_REGIONS=us-east-1,us-east2'
+      );
+    }
+    results.push(await loadAwsK8s(ES_CONFIG, { region: ['us-east-1', 'us-east-2'] }));
   }
 
   if (doAll || types.includes('azure-k8s')) {
@@ -32,12 +37,12 @@ export async function collectAssets({ types }: { types: string[] }) {
         'Cannot collect Azure K8s assets without a valid Azure Subscription ID provided as ASSETS_AZURE_SUBSCRIPTION_ID'
       );
     }
-    results.push(loadAzureK8s(ES_CONFIG, process.env.ASSETS_AZURE_SUBSCRIPTION_ID));
+    results.push(await loadAzureK8s(ES_CONFIG, process.env.ASSETS_AZURE_SUBSCRIPTION_ID));
   }
 
-  if (doAll || types.includes('')) {
-    results.push(loadK8sAssets(ES_CONFIG));
+  if (doAll || types.includes('k8s-api')) {
+    results.push(await loadK8sAssets(ES_CONFIG));
   }
 
-  return await Promise.all(results);
+  return results;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2314,10 +2314,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/asset-collection@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@elastic/asset-collection/-/asset-collection-0.3.0.tgz#f1785b174561be8eeea3898b3251f7a9012898a9"
-  integrity sha512-/fZ2yk2Eh7OkkWiWR8Xgr0nz6gjbVxp28xHZaM414ORkWL6u9VyGAoTZqJYxf3CJyjpJ6tDMQnbgiB9YAXlIlA==
+"@elastic/asset-collection@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@elastic/asset-collection/-/asset-collection-0.4.0.tgz#fbdb85a0bfdc400961072e7efddd50eb9320d86d"
+  integrity sha512-e4R9bJal03H6K9wM3pp3hCvCrC7PMAv3845EU+TNthCUdo7dl7CWLLoewOrh/VX/HffbBviji/YZG+nH2b+JYA==
   dependencies:
     "@aws-sdk/client-eks" "^3.218.0"
     "@azure/arm-containerservice" "^17.2.0"


### PR DESCRIPTION
## Summary

Errors with asset collection, available via a button on the kubernetes cluster listing page (/app/asset-inventory/k8s/clusters), are now gracefully handled with helpful error messages when the correct ENV vars are not set.

<img width="1228" alt="Screen Shot 2023-01-05 at 10 32 44 AM" src="https://user-images.githubusercontent.com/159370/210819878-e4e52cf9-7aec-421f-b5ff-5b37f5578dab.png">

<img width="1318" alt="Screen Shot 2023-01-05 at 10 32 51 AM" src="https://user-images.githubusercontent.com/159370/210819911-415c7edd-1b6e-475f-bd29-c6301bcc75f6.png">

<img width="1265" alt="Screen Shot 2023-01-05 at 10 34 47 AM" src="https://user-images.githubusercontent.com/159370/210819929-1a72775f-c9af-473b-82c2-bdc4f980a11e.png">

NOTE: For now, it's still required to provide AWS regions and Azure subscription IDs, as the collection process attempts to collect asset data from AWS, Azure, and the K8s API directly. To collect from *only* a subselection of these options, changes will need to be made, but the POC demo assumes all 3 for now.