### PR TITLE
Fix Cloud Data

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
-    "@elastic/asset-collection": "^0.4.0",
+    "@elastic/asset-collection": "0.5.0",
     "@elastic/charts": "51.3.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.5.0-canary.1",

--- a/x-pack/plugins/asset_inventory/common/types_api.ts
+++ b/x-pack/plugins/asset_inventory/common/types_api.ts
@@ -7,15 +7,32 @@
 
 export type AssetKind = 'unknown' | 'node';
 export type AssetType = 'k8s.pod' | 'k8s.cluster' | 'k8s.node';
+export type AssetStatus = 'CREATING' | 'ACTIVE' | 'DELETING' | 'FAILED' | 'UPDATING' | 'PENDING';
+export type CloudProviderName = 'aws' | 'gcp' | 'azure' | 'other' | 'unknown' | 'none';
 
 export interface ECSDocument {
   '@timestamp': string;
-  kubernetes?: EcsKubernetesFieldset;
-  orchestrator?: EcsOrchestratorFieldset;
-  cloud?: EcsCloudFieldset;
-}
 
-export type AssetStatus = 'CREATING' | 'ACTIVE' | 'DELETING' | 'FAILED' | 'UPDATING' | 'PENDING';
+  'kubernetes.namespace'?: string;
+  'kubernetes.pod.name'?: string;
+  'kubernetes.pod.uid'?: string;
+  'kubernetes.pod.start_time'?: Date;
+  'kubernetes.node.name'?: string;
+  'kubernetes.node.start_time'?: Date;
+
+  'orchestrator.api_version'?: string;
+  'orchestrator.namespace'?: string;
+  'orchestrator.organization'?: string;
+  'orchestrator.type'?: string;
+  'orchestrator.cluster.id'?: string;
+  'orchestrator.cluster.name'?: string;
+  'orchestrator.cluster.url'?: string;
+  'orchestrator.cluster.version'?: string;
+
+  'cloud.provider'?: CloudProviderName;
+  'cloud.region'?: string;
+  'cloud.service.name'?: string;
+}
 
 export interface Asset extends ECSDocument {
   'asset.collection_version'?: string;
@@ -49,52 +66,10 @@ export interface K8sCluster extends ECSDocument {
   name: string;
   nodes: K8sNode[];
   status: string;
-  version: string;
-}
-
-export interface EcsKubernetesFieldset {
-  namespace?: string;
-  pod?: {
-    name: string;
-    uid: string;
-    start_time?: Date;
-  };
-  node?: {
-    name: string;
-    start_time?: Date;
-  };
-}
-
-// See: https://www.elastic.co/guide/en/ecs/current/ecs-orchestrator.html
-export interface EcsOrchestratorFieldset {
-  api_version?: string;
-  namespace?: string;
-  organization?: string;
-  type?: string;
-  cluster?: {
-    id?: string;
-    name?: string;
-    url?: string;
-    version?: string;
-  };
-  resource?: {
-    id?: string;
-    ip?: string;
-    name?: string;
-    type?: string;
-    parent?: {
-      type?: string;
-    };
-  };
-}
-
-export type CloudProviderName = 'aws' | 'gcp' | 'azure' | 'other' | 'unknown' | 'none';
-
-export interface EcsCloudFieldset {
-  provider: CloudProviderName;
-  region?: string;
-  service?: {
-    name?: string;
+  version?: string;
+  cloud: {
+    provider?: CloudProviderName;
+    region?: string;
   };
 }
 

--- a/x-pack/plugins/asset_inventory/public/pages/k8s/clusters_list_page.tsx
+++ b/x-pack/plugins/asset_inventory/public/pages/k8s/clusters_list_page.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useEffect, useState } from 'react';
-import { EuiButton, EuiCallOut, EuiLoadingSpinner, EuiPageTemplate } from '@elastic/eui';
+import { EuiButton, EuiCallOut, EuiLoadingSpinner, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
 import axios from 'axios';
 import { useHistory } from 'react-router-dom';
 import { LoadResults } from '@elastic/asset-collection/dist/lib/shared/types';
@@ -107,37 +107,27 @@ interface CollectionMessageProps {
 }
 
 function CollectionMessage({ isCollecting, response, error, timeoutMs }: CollectionMessageProps) {
-  const [show, setShow] = useState<boolean>(false);
-  const [showTimeout, setShowTimeout] = useState<NodeJS.Timeout | null>(null);
-
-  useEffect(() => {
-    if (showTimeout) {
-      clearTimeout(showTimeout);
-    }
-    setShow(true);
-    const t = setTimeout(() => setShow(false), timeoutMs);
-    setShowTimeout(t);
-  }, [isCollecting, response, error, showTimeout, timeoutMs]);
-
-  if (!show) {
-    return null;
-  }
-
   if (isCollecting) {
     return null;
   }
 
   if (error) {
     return (
-      <EuiCallOut title="Collection Failed" color="danger">
-        {error}
-      </EuiCallOut>
+      <>
+        <EuiCallOut title="Collection Failed" color="danger">
+          {error}
+        </EuiCallOut>
+        <EuiSpacer />
+      </>
     );
   }
 
   if (response) {
     return (
-      <EuiCallOut title="Collection Succeeded" color="success" iconType="checkInCircleFilled" />
+      <>
+        <EuiCallOut title="Collection Succeeded" color="success" iconType="checkInCircleFilled" />
+        <EuiSpacer />
+      </>
     );
   }
 

--- a/x-pack/plugins/asset_inventory/server/lib/collect_assets.ts
+++ b/x-pack/plugins/asset_inventory/server/lib/collect_assets.ts
@@ -28,7 +28,9 @@ export async function collectAssets({ types }: { types: string[] }) {
         'Cannot collect AWS K8s assets without specifying one or more valid AWS regions, provided as ASSETS_AWS_REGIONS=us-east-1,us-east2'
       );
     }
-    results.push(await loadAwsK8s(ES_CONFIG, { region: ['us-east-1', 'us-east-2'] }));
+    results.push(
+      await loadAwsK8s(ES_CONFIG, { region: process.env.ASSETS_AWS_REGIONS.split(',') })
+    );
   }
 
   if (doAll || types.includes('azure-k8s')) {

--- a/x-pack/plugins/asset_inventory/server/lib/get_k8s_clusters.ts
+++ b/x-pack/plugins/asset_inventory/server/lib/get_k8s_clusters.ts
@@ -51,8 +51,11 @@ export async function getK8sClusters(): Promise<K8sCluster[]> {
         name: doc['asset.name'] || doc['asset.id'],
         nodes: await getK8sNodes({ clusterEan: doc['asset.ean'] }),
         status: doc['asset.status'] || 'UNKNOWN',
-        cloud: doc.cloud,
-        version: doc.orchestrator?.cluster?.version || 'Unspecified',
+        cloud: {
+          provider: doc['cloud.provider'],
+          region: doc['cloud.region'],
+        },
+        version: doc['orchestrator.cluster.version'],
       };
     })
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,10 +2318,10 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/asset-collection@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@elastic/asset-collection/-/asset-collection-0.4.0.tgz#fbdb85a0bfdc400961072e7efddd50eb9320d86d"
-  integrity sha512-e4R9bJal03H6K9wM3pp3hCvCrC7PMAv3845EU+TNthCUdo7dl7CWLLoewOrh/VX/HffbBviji/YZG+nH2b+JYA==
+"@elastic/asset-collection@0.5.0":
+  version "0.5.0"
+  resolved "https://registry.npmjs.org/@elastic/asset-collection/-/asset-collection-0.5.0.tgz#a7df0c9bbc4e2fe349d472d89d835ea8ad3138f6"
+  integrity sha512-K9pL0C8tzeZ4jNhQn2BZ00r6pQ3pcjHRgTY9J3ak1xG3sTmtXm3OAdg0qRnAvE/YmKB9ZPQraG+R4Du2S1AYZg==
   dependencies:
     "@aws-sdk/client-eks" "^3.218.0"
     "@azure/arm-containerservice" "^17.2.0"


### PR DESCRIPTION
## Summary

Cloud provider data is now available for Azure, AWS, and Google. Kubernetes version as well. If you have you kubectl connected to cloud k8s accounts, you should see cluster listings with node counts (and there will be connected pods stored below that as well).

This PR depends on @elastic/asset-collection version 0.5.0

NOTE: Asset resolution relies on manually-kept unique cluster names for now.

<img width="1287" alt="Screen Shot 2023-01-09 at 9 32 55 PM" src="https://user-images.githubusercontent.com/159370/211448747-c1596f66-cf1f-4c05-b879-0ce7e7b53a8d.png">

