### PR TITLE
Fix cloud data ingest

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@dnd-kit/utilities": "^2.0.0",
     "@elastic/apm-rum": "^5.12.0",
     "@elastic/apm-rum-react": "^1.4.2",
-    "@elastic/asset-collection": "0.5.0",
+    "@elastic/asset-collection": "^0.5.0",
     "@elastic/charts": "51.3.0",
     "@elastic/datemath": "5.0.3",
     "@elastic/elasticsearch": "npm:@elastic/elasticsearch-canary@8.5.0-canary.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,7 +2318,7 @@
   dependencies:
     object-hash "^1.3.0"
 
-"@elastic/asset-collection@0.5.0":
+"@elastic/asset-collection@^0.5.0":
   version "0.5.0"
   resolved "https://registry.npmjs.org/@elastic/asset-collection/-/asset-collection-0.5.0.tgz#a7df0c9bbc4e2fe349d472d89d835ea8ad3138f6"
   integrity sha512-K9pL0C8tzeZ4jNhQn2BZ00r6pQ3pcjHRgTY9J3ak1xG3sTmtXm3OAdg0qRnAvE/YmKB9ZPQraG+R4Du2S1AYZg==


### PR DESCRIPTION
## Summary

Some of the cloud data values weren't being stored correctly, so the nodes couldn't be connected to their clusters. This PR adopts the latest version of the asset-collection package and fixes those problems.